### PR TITLE
Change install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Production server is available at [frolfr.com](http://frolfr.com).
 To install and deploy:
 * Pull down repository
 * `bundle install`
-* rake db:create:all
-* rake db:migrate
-* rake db:seed
-* `unicorn`
+* `rake db:create:all`
+* `rake db:schema:load`
+* `rake db:seed`
+* `bundle exec unicorn`
 
 To run tests, run `rake db:test:prepare; rspec`.
 


### PR DESCRIPTION
I ran into errors running `rake db:migrate`, and then I ran into conflicts between my local version of Unicorn and the one required by Frolfr.
