### PR TITLE
Fixing Up Round Rendering

### DIFF
--- a/app/controllers/api/course_scorecards_controller.rb
+++ b/app/controllers/api/course_scorecards_controller.rb
@@ -1,0 +1,9 @@
+class Api::CourseScorecardsController < ApplicationController
+  respond_to :json
+
+  def index
+    course = Course.find(params[:course_id])
+    scorecards = current_user.scorecards.for_course(course)
+    respond_with :api, scorecards, each_serializer: CourseScorecardSerializer
+  end
+end

--- a/app/controllers/api/joint_rounds_controller.rb
+++ b/app/controllers/api/joint_rounds_controller.rb
@@ -3,6 +3,6 @@ class Api::JointRoundsController < ApplicationController
 
   def index
     user = User.find(params[:user_id])
-    respond_with current_user.rounds_with_user(user).by_date
+    respond_with current_user.rounds_with_user(user).by_date, each_serializer: JointRoundSerializer
   end
 end

--- a/app/controllers/api/leaderboard_scorecards_controller.rb
+++ b/app/controllers/api/leaderboard_scorecards_controller.rb
@@ -1,0 +1,10 @@
+class Api::LeaderboardScorecardsController < ApplicationController
+  respond_to :json
+
+  def index
+    course = Course.find(params[:course_id])
+    leaderboard = Leaderboard.new(course)
+
+    respond_with :api, leaderboard.scorecards, each_serializer: LeaderboardScorecardSerializer
+  end
+end

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -1,0 +1,12 @@
+class Leaderboard
+  attr_reader :course
+
+  def initialize(course)
+    @course = course
+  end
+
+  def scorecards
+    course.scorecards
+  end
+end
+

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -16,7 +16,7 @@ class Leaderboard
   end
 
   def sorted_scorecards
-    complete_course_scorecards.sort_by(&:total_shooting)
+    complete_course_scorecards.sort_by(&:score)
   end
 
   def complete_course_scorecards

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -6,10 +6,14 @@ class Leaderboard
   end
 
   def scorecards
-    sorted_scorecards.uniq(&:user_id)
+    unique_scorecards.take(10)
   end
 
   private
+
+  def unique_scorecards
+    sorted_scorecards.uniq(&:user_id)
+  end
 
   def sorted_scorecards
     complete_course_scorecards.sort_by(&:total_shooting)

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -6,7 +6,13 @@ class Leaderboard
   end
 
   def scorecards
-    course.scorecards
+    complete_course_scorecards
+  end
+
+  private
+
+  def complete_course_scorecards
+    course.scorecards.select(&:completed?)
   end
 end
 

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -6,7 +6,7 @@ class Leaderboard
   end
 
   def scorecards
-    complete_course_scorecards
+    complete_course_scorecards.sort_by(&:total_shooting)
   end
 
   private

--- a/app/models/leaderboard.rb
+++ b/app/models/leaderboard.rb
@@ -6,10 +6,14 @@ class Leaderboard
   end
 
   def scorecards
-    complete_course_scorecards.sort_by(&:total_shooting)
+    sorted_scorecards.uniq(&:user_id)
   end
 
   private
+
+  def sorted_scorecards
+    complete_course_scorecards.sort_by(&:total_shooting)
+  end
 
   def complete_course_scorecards
     course.scorecards.select(&:completed?)

--- a/app/models/scorecard.rb
+++ b/app/models/scorecard.rb
@@ -8,11 +8,20 @@ class Scorecard < ActiveRecord::Base
   # TODO: validate that scorecard has as many turns as a course has holes
 
   scope :by_date, -> { joins(:round).order('rounds.created_at DESC') }
+  scope :for_course, ->(course) { joins(:round).where(rounds: { course_id: course.id })}
 
   delegate :course, to: :round
 
   def score
-    turns.sum(:score)
+    played_turns.sum(:score)
+  end
+
+  def total_par
+    played_turns.sum(:par)
+  end
+
+  def total_shooting
+    score - total_par
   end
 
   def completed?
@@ -25,5 +34,11 @@ class Scorecard < ActiveRecord::Base
 
   def started?
     turns.any? { |turn| turn.score.present? }
+  end
+
+  private
+
+  def played_turns
+    turns.where.not(score: nil)
   end
 end

--- a/app/serializers/course_scorecard_serializer.rb
+++ b/app/serializers/course_scorecard_serializer.rb
@@ -1,0 +1,15 @@
+class CourseScorecardSerializer < ActiveModel::Serializer
+  attributes :id, :total_score, :total_shooting, :created_at, :round_id, :is_completed
+
+  def created_at
+    object.round.created_at
+  end
+
+  def total_score
+    object.score
+  end
+
+  def is_completed
+    object.completed?
+  end
+end

--- a/app/serializers/joint_round_serializer.rb
+++ b/app/serializers/joint_round_serializer.rb
@@ -1,0 +1,7 @@
+class JointRoundSerializer < ActiveModel::Serializer
+  attributes :id, :course_name, :created_at
+
+  def course_name
+    object.course.name
+  end
+end

--- a/app/serializers/leaderboard_scorecard_serializer.rb
+++ b/app/serializers/leaderboard_scorecard_serializer.rb
@@ -1,0 +1,21 @@
+class LeaderboardScorecardSerializer < ActiveModel::Serializer
+  attributes :id, :total_score, :total_shooting, :created_at, :user_full_name
+
+  def created_at
+    object.round.created_at
+  end
+
+  def total_score
+    object.score
+  end
+
+  def user_full_name
+    [user.first_name, user.middle_name, user.last_name].join(" ")
+  end
+
+  private
+
+  def user
+    object.user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Frolfr::Application.routes.draw do
       json.resources :friends
       json.resources :user_stat_logs
       json.resources :course_stat_logs
+      json.resources :leaderboard_scorecards
       json.resources :course_scorecards
       json.resources :users
       json.resources :friendable_users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Frolfr::Application.routes.draw do
       json.resources :friends
       json.resources :user_stat_logs
       json.resources :course_stat_logs
+      json.resources :course_scorecards
       json.resources :users
       json.resources :friendable_users
       json.resources :rounds

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -15,6 +15,13 @@ describe Leaderboard do
         FactoryGirl.create(:scorecard)
         expect(subject.scorecards).to match_array [scorecard]
       end
+
+      it 'only includes complete scorecards' do
+        incomplete_scorecard = FactoryGirl.create(:scorecard, round: round)
+        FactoryGirl.create(:turn, scorecard: incomplete_scorecard, score: nil)
+
+        expect(subject.scorecards).to match_array [scorecard]
+      end
     end
   end
 end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -22,6 +22,18 @@ describe Leaderboard do
 
         expect(subject.scorecards).to match_array [scorecard]
       end
+
+      it 'orders scorecards by performance against par' do
+        worst_scorecard = FactoryGirl.create(:scorecard, round: round)
+        FactoryGirl.create(:turn, scorecard: worst_scorecard, score: 5)
+
+        best_scorecard = FactoryGirl.create(:scorecard, round: round)
+        FactoryGirl.create(:turn, scorecard: best_scorecard, score: 1)
+
+        expect(subject.scorecards).to match_array Scorecard.all
+        expect(subject.scorecards.first).to eq best_scorecard
+        expect(subject.scorecards.last).to eq worst_scorecard
+      end
     end
   end
 end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Leaderboard do
+  let(:course) { FactoryGirl.create(:course) }
+  let(:round) { FactoryGirl.create(:round, course: course) }
+  let(:scorecard) { FactoryGirl.create(:scorecard, round: round) }
+  let!(:turn) { FactoryGirl.create(:turn, scorecard: scorecard, score: 3) }
+  let(:user) { scorecard.user }
+
+  subject(:leaderboard) { described_class.new(course) }
+
+  context 'scorecards for a one-hole course' do
+    describe '#scorecards' do
+      it 'only returns scorecards from that course' do
+        FactoryGirl.create(:scorecard)
+        expect(subject.scorecards).to match_array [scorecard]
+      end
+    end
+  end
+end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -40,6 +40,11 @@ describe Leaderboard do
         FactoryGirl.create(:scorecard, user: user, round: other_round)
         expect(subject.scorecards).to match_array [scorecard]
       end
+
+      it 'is limited to 10 scorecards' do
+        FactoryGirl.create_list(:scorecard, 11, round: round)
+        expect(subject.scorecards.count).to eq 10
+      end
     end
   end
 end

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -35,10 +35,14 @@ describe Leaderboard do
         expect(subject.scorecards.last).to eq worst_scorecard
       end
 
-      it 'is unique by user' do
-        other_round = FactoryGirl.create(:round, course: course)
-        FactoryGirl.create(:scorecard, user: user, round: other_round)
-        expect(subject.scorecards).to match_array [scorecard]
+      context 'uniqueness by user' do
+        it 'returns the better scorecard' do
+          best_round = FactoryGirl.create(:round, course: course)
+          best_scorecard = FactoryGirl.create(:scorecard, user: user, round: round)
+          FactoryGirl.create(:turn, scorecard: best_scorecard, score: 1)
+
+          expect(subject.scorecards).to match_array [best_scorecard]
+        end
       end
 
       it 'is limited to 10 scorecards' do

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -23,7 +23,7 @@ describe Leaderboard do
         expect(subject.scorecards).to match_array [scorecard]
       end
 
-      it 'orders scorecards by performance against par' do
+      it 'orders scorecards by score' do
         worst_scorecard = FactoryGirl.create(:scorecard, round: round)
         FactoryGirl.create(:turn, scorecard: worst_scorecard, score: 5)
 

--- a/spec/models/leaderboard_spec.rb
+++ b/spec/models/leaderboard_spec.rb
@@ -34,6 +34,12 @@ describe Leaderboard do
         expect(subject.scorecards.first).to eq best_scorecard
         expect(subject.scorecards.last).to eq worst_scorecard
       end
+
+      it 'is unique by user' do
+        other_round = FactoryGirl.create(:round, course: course)
+        FactoryGirl.create(:scorecard, user: user, round: other_round)
+        expect(subject.scorecards).to match_array [scorecard]
+      end
     end
   end
 end

--- a/spec/requests/api/course_scorecards_spec.rb
+++ b/spec/requests/api/course_scorecards_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Api::CourseScorecardsController do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe "GET index" do
+    let(:course) { FactoryGirl.create(:course) }
+    let(:round) { FactoryGirl.create(:round, course: course) }
+    let!(:scorecard) { FactoryGirl.create(:scorecard, round: round, user: user) }
+    let(:send_request) { get api_course_scorecards_path, { format: :json, course_id: course.id }, auth_header(user) }
+
+    before { send_request }
+
+    it 'has a code of 200' do
+      expect(response).to be_ok
+    end
+
+    it 'has scorecard attributes' do
+      json_scorecard = json['course_scorecards'].first
+      expect(json_scorecard['id']).to eq scorecard.id
+      expect(json_scorecard).to have_key 'total_score'
+      expect(json_scorecard).to have_key 'total_shooting'
+      expect(json_scorecard).to have_key 'created_at'
+      expect(json_scorecard).to have_key 'round_id'
+      expect(json_scorecard).to have_key 'is_completed'
+    end
+  end
+end

--- a/spec/requests/api/joint_rounds_spec.rb
+++ b/spec/requests/api/joint_rounds_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Api::JointRoundsController do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:friend) { FactoryGirl.create(:user) }
+  let(:round) { FactoryGirl.create(:round) }
+
+  before do
+    FactoryGirl.create(:scorecard, round: round, user: user)
+    FactoryGirl.create(:scorecard, round: round, user: friend)
+  end
+
+  describe "GET index" do
+    let(:send_request) { get api_joint_rounds_path, { format: :json, user_id: friend.id }, auth_header(user) }
+
+    before { send_request }
+
+    it 'has a code of 200' do
+      expect(response).to be_ok
+    end
+
+    it 'has round attributes' do
+      json_round = json['joint_rounds'].first
+      expect(json_round['id']).to eq round.id
+      expect(json_round).to have_key 'created_at'
+      expect(json_round).to have_key 'course_name'
+    end
+  end
+end

--- a/spec/requests/api/leaderboard_scorecards_spec.rb
+++ b/spec/requests/api/leaderboard_scorecards_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Api::LeaderboardScorecardsController do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe "GET index" do
+    let(:course) { FactoryGirl.create(:course) }
+    let(:round) { FactoryGirl.create(:round, course: course) }
+    let!(:scorecard) { FactoryGirl.create(:scorecard, round: round, user: user) }
+    let(:send_request) { get api_leaderboard_scorecards_path, { format: :json, course_id: course.id }, auth_header(user) }
+
+    before { send_request }
+
+    it 'has a code of 200' do
+      expect(response).to be_ok
+    end
+
+    it 'has scorecard attributes' do
+      json_scorecard = json['leaderboard_scorecards'].first
+      expect(json_scorecard['id']).to eq scorecard.id
+      expect(json_scorecard).to have_key 'total_score'
+      expect(json_scorecard).to have_key 'total_shooting'
+      expect(json_scorecard).to have_key 'created_at'
+      expect(json_scorecard).to have_key 'user_full_name'
+    end
+  end
+end


### PR DESCRIPTION
WIP

DONE:
* Moves rounds table to courses template
* Adds filtering out "incomplete scorecards" feature
* Moves most logic to Rails land
* Cleans up profile page

TODO:
* Find a place to put newly started rounds
* Break out serializers between the newly started rounds (rounds that should always include scorecards/turns) and complete/finished rounds (rounds that don't necessarily need scorecard/turn information on first load)
* Peeerrrrrhaps have a place for all rounds to be seen? I dunno if this is a really worthwhile thing
* The "jointRounds" template shouldn't have to load scorecard/turn data. Consider breaking it out as a new serializer

[Closes #131]