### PR TITLE
Ensures users who have played only solo rounds can see profile data

### DIFF
--- a/app/models/profile_stat_log.rb
+++ b/app/models/profile_stat_log.rb
@@ -31,11 +31,19 @@ class ProfileStatLog
   end
 
   def top_friend_name
-    top_friend_data.first.full_name unless courses_played.zero?
+    if !courses_played.zero? && top_friend_data
+      top_friend_data.first.full_name
+    else
+      "None"
+    end
   end
 
   def top_friend_rounds_count
-    courses_played.zero? ? 0 : top_friend_data.count
+    if !courses_played.zero? && top_friend_data
+      top_friend_data.count
+    else
+      0
+    end
   end
 
   def top_played_course_data

--- a/spec/models/profile_stat_log_spec.rb
+++ b/spec/models/profile_stat_log_spec.rb
@@ -35,6 +35,16 @@ describe ProfileStatLog do
         expect(subject.top_friend_rounds_count).to eq rounds_count
       end
     end
+
+    context "only played solo rounds" do
+      it 'returns default values' do
+        user = FactoryGirl.create(:scorecard).user
+        subject = described_class.new(user)
+
+        expect(subject.top_friend_name).to eq "None"
+        expect(subject.top_friend_rounds_count).to eq 0
+      end
+    end
   end
 
   describe "top course" do


### PR DESCRIPTION
* Fills in some default values
* Fixes https://github.com/frolfr/frolfr-server/issues/199

<img width="387" alt="screen shot 2016-08-18 at 3 21 49 pm" src="https://cloud.githubusercontent.com/assets/2623668/17787549/98187800-6557-11e6-8773-223e07ae70fc.png">
