### PR TITLE
Make public_recap boolean default to true

### DIFF
--- a/db/migrate/20170217013949_change_column_default_of_public_recap.rb
+++ b/db/migrate/20170217013949_change_column_default_of_public_recap.rb
@@ -1,0 +1,9 @@
+class ChangeColumnDefaultOfPublicRecap < ActiveRecord::Migration
+  def up
+    change_column_default :rounds, :public_recap, true
+  end
+
+  def down
+    change_column_default :rounds, :public_recap, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150707002634) do
+ActiveRecord::Schema.define(version: 20170217013949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20150707002634) do
     t.integer  "course_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "public_recap", default: false, null: false
+    t.boolean  "public_recap", default: true, null: false
   end
 
   add_index "rounds", ["course_id"], name: "index_rounds_on_course_id", using: :btree


### PR DESCRIPTION
* This kinda sucks, because this part of the client has been technically removed.
* Oh well, it’s still live on frolfr.com, so will work for now

The goal of this is to have a link to send to non-frolfr users for social media and Slack bots